### PR TITLE
Fixed issue with including Form  on other page. 

### DIFF
--- a/code/ContactForm.php
+++ b/code/ContactForm.php
@@ -264,7 +264,7 @@ class ContactForm extends Object {
 	 * @param string The email address to which the form will send the email
 	 * @param string The subject of the email
 	 */
-	public function __construct($name, $to, $subject) {		
+	public function __construct($controller, $name, $to, $subject) {		
 		$this->toAddress = $to;
 		$this->messageSubject = $subject;	
 		$formClass = $this->isBootstrap() ? "BootstrapForm" : "Form";		
@@ -272,7 +272,7 @@ class ContactForm extends Object {
 		$this->setSpamProtection($spam);
 
 		$this->form = Object::create($formClass,
-			Controller::curr(),
+			$controller,
 			$name,
 			FieldList::create(),
 			FieldList::create(

--- a/code/ContactFormPage.php
+++ b/code/ContactFormPage.php
@@ -59,7 +59,7 @@ class ContactFormPage_Controller extends Page_Controller {
 	 * @return ContactForm
 	 */
 	public function Form() {
-		return ContactForm::create("Form", $this->To, $this->Subject)
+		return ContactForm::create($this, "Form", $this->To, $this->Subject)
 			->setSuccessMessage($this->SuccessMessage)
 			->setIntroText($this->IntroText);
 	}


### PR DESCRIPTION
I have followed the instruction on readme page, to create sub-class MyContactPage form ContactFormPage, and create page on cms, and can see the form on 'url/contact' ie contact page.

When I try to include the contact form in HomePage, the form get displayed, but form action is set as 'url/home/Form' while I want the form action attritbute like 'url/contact/Form'. so that form get submitted to contact page and processed.

Below is the code from HomePage_Controller.php

public static function Form(){
	$page =  MyContactPage::get()->First();		
	if($page){
		$controller = new MyContactPage_Controller($page);
		$form = $controller->Form();
		return $form;
	}
}
